### PR TITLE
Pass to bash instead of running the string as arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,6 @@ inputs:
     required: false
 
 runs:
-  using: node16
+  using: node20
   main: dist/main/index.js
   post: dist/post/index.js

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,6 @@ inputs:
     required: false
 
 runs:
-  using: node12
+  using: node16
   main: dist/main/index.js
   post: dist/post/index.js

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -1754,7 +1754,8 @@ function exec(commandLine, args, options) {
         const runner = new tr.ToolRunner(
             "bash",
             [ "--noprofile",
-              "-e",
+              "--norc",
+              "-euo", "pipefail",
               "-c", commandLine
             ],
             options

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -1751,7 +1751,14 @@ const tr = __importStar(__webpack_require__(9));
  */
 function exec(commandLine, args, options) {
     return __awaiter(this, void 0, void 0, function* () {
-        const runner = new tr.ToolRunner("bash", ["-euo", "pipefail", "-c", commandLine], options);
+        const runner = new tr.ToolRunner(
+            "bash",
+            [ "--noprofile",
+              "-euo", "pipefail",
+              "-c", commandLine
+            ],
+            options
+        );
         return runner.exec();
     });
 }

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -1751,14 +1751,7 @@ const tr = __importStar(__webpack_require__(9));
  */
 function exec(commandLine, args, options) {
     return __awaiter(this, void 0, void 0, function* () {
-        const commandArgs = tr.argStringToArray(commandLine);
-        if (commandArgs.length === 0) {
-            throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
-        }
-        // Path to tool to execute should be first arg
-        const toolPath = commandArgs[0];
-        args = commandArgs.slice(1).concat(args || []);
-        const runner = new tr.ToolRunner(toolPath, args, options);
+        const runner = new tr.ToolRunner("bash", ["-euo", "pipefail", "-c", commandLine], options);
         return runner.exec();
     });
 }

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -1754,7 +1754,7 @@ function exec(commandLine, args, options) {
         const runner = new tr.ToolRunner(
             "bash",
             [ "--noprofile",
-              "-euo", "pipefail",
+              "-e",
               "-c", commandLine
             ],
             options


### PR DESCRIPTION
This makes the action behave similarly to the `run` in step, which is passed to `bash -e`.
I decided I wanted to have more security by default, so I use `-euo pipefail`, but that could be changed.

Iff this is merged, this should be a new major version of the action.