### PR TITLE
Add `skip-on-failure` option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,4 +20,4 @@ runs:
   using: node12
   main: dist/main/index.js
   post: dist/post/index.js
-  post-if: ${{ inputs.skip-on-failure != 'true' || success() }}
+  post-if: ${{ env.INPUT_SKIP-ON-FAILURE != 'true' || success() }}

--- a/action.yml
+++ b/action.yml
@@ -20,4 +20,4 @@ runs:
   using: node12
   main: dist/main/index.js
   post: dist/post/index.js
-  post-if: "!inputs.skip-on-failure || success()"
+  post-if: ${{ inputs.skip-on-failure != 'true' || success() }}

--- a/action.yml
+++ b/action.yml
@@ -20,4 +20,4 @@ runs:
   using: node12
   main: dist/main/index.js
   post: dist/post/index.js
-  post-if: '!inputs.skip-on-failure || success()'
+  post-if: "!inputs.skip-on-failure || success()"

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,14 @@ inputs:
   working-directory:
     description: "A working directory from which the command needs to be run."
     required: false
+    
+  skip-on-failure:
+    description: "Set to true to not run the command if the job fails."
+    required: false
+    default: false
 
 runs:
   using: node12
   main: dist/main/index.js
   post: dist/post/index.js
+  post-if: '!inputs.skip-on-failure || success()'


### PR DESCRIPTION
Add a new`skip-on-failure` option, which (if set to true) skips the post-run action if the job fails. Defaults to false.

This is really useful for our use case, where we only want to run certain after-action steps if the job succeeds.