### PR TITLE
Upgrade from node16 to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,6 @@ inputs:
     required: false
 
 runs:
-  using: node16
+  using: node20
   main: dist/main/index.js
   post: dist/post/index.js


### PR DESCRIPTION
Node 16 has reached end of life, so GitHub is deprecating it and adding warnings to any actions that use it.

See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/